### PR TITLE
FIX :: MessagePreview selection range parser no longer always returns null

### DIFF
--- a/tf2-chat-colouriser/app/components/chat/message-preview.vue
+++ b/tf2-chat-colouriser/app/components/chat/message-preview.vue
@@ -98,7 +98,7 @@
 
 				const globalEndIndex: number = globalStartIndex + (textNode.textContent?.length ?? 0);
 				if (selection.equals(new IndexRange(globalStartIndex, globalEndIndex))) {
-					const selectionRange: Range = document.createRange();
+					selectionRange = document.createRange();
 					selectionRange.setStart(textNode, selection.startIndex - globalStartIndex);
 					selectionRange.setEnd(textNode, selection.endIndex - globalStartIndex);
 				}


### PR DESCRIPTION
### Issues Fixed
Closes #35. again.

### Overview
Inner for-loop would set a completely new variable instead of modifying the one already existing. How this wasn't a compile-time error from namespace pollution (two variables with character-for-character equivalent names) is beyond me.