### PR TITLE
REFACTOR :: Deploy GitHub Pages Only on Releases

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -2,9 +2,8 @@
 name: Deploy to GitHub Pages
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Issues Fixed
Closes #40.

### Overview
Rather than deploying every time a push is made to main, causing some broken deployments when a merged PR brought unintended issues, the GH Pages will now only deploy when a release is published and (hopefully) major issues have been resolved